### PR TITLE
Update integration test

### DIFF
--- a/integration-test/test/basic.bats
+++ b/integration-test/test/basic.bats
@@ -9,7 +9,7 @@ load test_helper
 }
 
 @test "meta: azure cli is installed" {
-    run azure -v
+    run az -v
     echo "$output">&2
     [ "$status" -eq 0 ]
 }

--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -231,9 +231,9 @@ teardown(){
     [[ "$diff" == *"A /var/lib/waagent/run-command/download/0/$blob2"* ]] # file downloaded
 
     # compare checksum
-    existing=$(md5 -q "$tmp")
+    existing=$(md5sum "$tmp" | cut -d " " -f 1)
     echo "Local file checksum: $existing"
-    got=$(container_read_file "/var/lib/waagent/run-command/download/0/$blob1" | md5 -q)
+    got=$(container_read_file "/var/lib/waagent/run-command/download/0/$blob1" | md5sum | cut -d " " -f 1)
     echo "Downloaded file checksum: $got"
     [[ "$existing" == "$got" ]]
 }

--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -200,10 +200,10 @@ teardown(){
     cnt="testcontainer"
     blob1="blob1-$RANDOM"
     blob2="blob2 with spaces-$RANDOM"
-    azure storage container show  "$cnt" 1>/dev/null ||
-        azure storage container create "$cnt" 1>/dev/null && echo "Azure Storage container created">&2
-    azure storage blob upload -f "$tmp" "$cnt" "$blob1" 1>/dev/null  # upload blob1
-    azure storage blob upload -f "$tmp" "$cnt" "$blob2" 1>/dev/null # upload blob2
+    az storage container show -n "$cnt" 1>/dev/null ||
+        az storage container create -n "$cnt" 1>/dev/null && echo "Azure Storage container created">&2
+    az storage blob upload -f "$tmp" -c "$cnt" -n "$blob1" 1>/dev/null # upload blob1
+    az storage blob upload -f "$tmp" -c "$cnt" -n "$blob2" 1>/dev/null # upload blob2
 
     blob1_url="http://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$cnt/$blob1" # over http
     blob2_url="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$cnt/$blob2" # over https


### PR DESCRIPTION
 As most people nowadays use azure-cli v2.x, I have replace the **azure** command with **az** in the integration script in the first commit.

There is no **md5** command on linux, so I have replaced the **md5** command with **md5sum** in the second commit. (if you are using osx you can install the command using `brew install md5sha1sum`)

