### PR TITLE
Replace /bin/sh with /bin/bash

### DIFF
--- a/main/exec.go
+++ b/main/exec.go
@@ -20,7 +20,7 @@ func Exec(cmd, workdir string, stdout, stderr io.WriteCloser) (int, error) {
 	defer stdout.Close()
 	defer stderr.Close()
 
-	c := exec.Command("/bin/sh", "-c", cmd)
+	c := exec.Command("/bin/bash", "-c", cmd)
 	c.Dir = workdir
 	c.Stdout = stdout
 	c.Stderr = stderr


### PR DESCRIPTION
Please Change /bin/sh with /bin/bash
On Ubuntu /bin/sh is a link to /bin/dash which leads to issues with certain scripts.
Therfore a change to /bin/bash is required. Otherwise it is reuired to perform the change manually
sudo rm -f /bin/sh
sudo ln -s /bin/bash /bin/sh